### PR TITLE
fix(deps): pin 'google-{api,cloud}-core', 'google-auth' to allow 2.x versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ version = "0.1.0"
 release_status = "Development Status :: 4 - Beta"
 url = "https://github.com/googleapis/python-iap"
 dependencies = [
-    "google-api-core[grpc] >= 1.27.0, <2.0.0dev",
+    # NOTE: Maintainers, please do not require google-api-core>=2.x.x
+    # Until this issue is closed
+    # https://github.com/googleapis/google-cloud-python/issues/10566
+    "google-api-core[grpc] >= 1.27.0, <3.0.0dev",
     "proto-plus >= 1.15.0",
     "packaging >= 14.3",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",


### PR DESCRIPTION
Expand pins on library dependencies in preparation for these dependencies taking a new major version. See https://github.com/googleapis/google-cloud-python/issues/10566.