### PR TITLE
chore: revert owlbot main branch templates

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -40,37 +40,3 @@ s.move(templated_files, excludes=[".coveragerc"]) # the microgenerator has a goo
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 
-# ----------------------------------------------------------------------------
-# Main Branch migration
-# ----------------------------------------------------------------------------
-
-s.replace(
-  "*.rst",
-  "master",
-  "main"
-)
-
-s.replace(
-  "CONTRIBUTING.rst",
-  "kubernetes/community/blob/main",
-  "kubernetes/community/blob/master"
-)
-
-s.replace(
-  "docs/*",
-  "master",
-  "main"
-)
-
-s.replace(
-  "docs/conf.py",
-  "main_doc",
-  "root_doc"
-)
-
-s.replace(
-  ".kokoro/*",
-  "master",
-  "main"
-)
-


### PR DESCRIPTION
Reverts main branch template for OwlBot that were included for the main branch integration.