### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "iap",
     "name_pretty": "Identity-Aware Proxy",
     "product_documentation": "https://cloud.google.com/iap",
-    "client_documentation": "https://googleapis.dev/python/iap/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/iap/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ access to Google Cloud hosted resources and applications hosted on Google Cloud.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-iap.svg
    :target: https://pypi.org/project/google-cloud-iap/
 .. _Identity-Aware Proxy: https://cloud.google.com/iap
-.. _Client Library Documentation: https://googleapis.dev/python/iap/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iap/latest
 .. _Product Documentation:  https://cloud.google.com/iap/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.